### PR TITLE
Fix GitHub Actions publish script

### DIFF
--- a/.github/workflows/react-reveal-effects-actions.yml
+++ b/.github/workflows/react-reveal-effects-actions.yml
@@ -24,6 +24,7 @@ jobs:
   publish-npm:
     needs: build
     runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/master'
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-reveal-effects",
   "author": "Titus Kipkemboi <tittohtech@gmail.com>",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "description": "Add fancy animations on scroll to your react application.",
   "keywords": [
     "react",


### PR DESCRIPTION
#### What does this PR do?
Fixes publish on pull request

#### Any background context you want to provide?
Github actions running on pull_request included the publish scripts. This caused npm-publish version errors when merged to master.

