### PR TITLE
Mark project as no longer maintained

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![npm](https://img.shields.io/npm/v/react-reveal-effects) ![GitHub Workflow Status](https://img.shields.io/github/workflow/status/tittoh/react-reveal-effects/React%20Reveal%20Effects) ![GitHub issues](https://img.shields.io/github/issues/tittoh/react-reveal-effects) ![Maintenance](https://img.shields.io/maintenance/yes/2021)
+![npm](https://img.shields.io/npm/v/react-reveal-effects) ![GitHub Workflow Status](https://img.shields.io/github/workflow/status/tittoh/react-reveal-effects/React%20Reveal%20Effects) ![GitHub issues](https://img.shields.io/github/issues/tittoh/react-reveal-effects) ![Maintenance](https://img.shields.io/maintenance/no/2021)
 # React Reveal Effects
 
 This package is an updated version of [react-reveal](https://github.com/rnosov/react-reveal) by Roman Nosov.


### PR DESCRIPTION
As this is not working with React 17, this library should be marked as no longer being maintained.

#### What does this PR do?

Mark library as not longer being maintained.

#### Any background context you want to provide?

Not working with React 17.

#### What are the relevant GitHub issues?

https://github.com/Tittoh/react-reveal-effects/issues/8